### PR TITLE
feat: add a "flux" file type

### DIFF
--- a/src/main/kotlin/com/influxdata/intellijflux/language/FluxFileType.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/FluxFileType.kt
@@ -1,0 +1,13 @@
+package com.influxdata.intellijflux.language
+
+import com.intellij.openapi.fileTypes.LanguageFileType
+
+object FluxFileType : LanguageFileType(FluxLanguage) {
+    override fun getName() = "Flux file"
+
+    override fun getDescription() = "Flux language file"
+
+    override fun getDefaultExtension() = "flux"
+
+    override fun getIcon() = FluxIcons.file
+}

--- a/src/main/kotlin/com/influxdata/intellijflux/language/FluxIcons.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/FluxIcons.kt
@@ -1,0 +1,8 @@
+package com.influxdata.intellijflux.language
+
+import com.intellij.openapi.util.IconLoader
+
+object FluxIcons {
+    @JvmField
+    val file = IconLoader.getIcon("/icons/flux.svg", FluxIcons.javaClass)
+}

--- a/src/main/kotlin/com/influxdata/intellijflux/language/FluxLanguage.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/FluxLanguage.kt
@@ -1,0 +1,6 @@
+package com.influxdata.intellijflux.language
+
+import com.intellij.lang.Language
+
+object FluxLanguage : Language("Flux") {
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,8 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
     <id>com.influxdata.intellijflux</id>
-    <name>intellij-flux</name>
+
+    <name>Flux Language Support</name>
     <vendor>InfluxData</vendor>
 
     <depends>com.intellij.modules.platform</depends>
@@ -9,6 +10,10 @@
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.influxdata.intellijflux.services.MyApplicationService"/>
         <projectService serviceImplementation="com.influxdata.intellijflux.services.MyProjectService"/>
+        <fileType name="Flux file"
+                  implementationClass="com.influxdata.intellijflux.language.FluxFileType"
+                  language="Flux"
+                  extensions="flux"/>
     </extensions>
 
     <applicationListeners>

--- a/src/main/resources/icons/flux.svg
+++ b/src/main/resources/icons/flux.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 2048 2048">
+	<circle fill-opacity="0.6" r="896" cx="1024" cy="1024" fill="#d776e0"></circle>
+	<g transform="scale(1)"><path fill-opacity="0.7" transform="translate(286.72, 1822.24) rotate(180) scale(-1, 1)" fill="#231f20" d="M856 1196l-16 -76h344l-43 -225h-344l-174 -895h-293l174 895h-273l43 225h273l16 78q42 211 134 284.5t331 73.5h240l-43 -225h-230q-65 0 -94 -27.5t-45 -107.5z"></path></g>
+</svg>


### PR DESCRIPTION
This creates a Flux language and makes it so any files with the `.flux` extension are assigned that language. By running the `runIde` Gradle task, you can see an `f` logo associated with Flux files.