### PR TITLE
feat: Automatically connect to flux-lsp

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ platformVersion = 2020.3.4
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins =
+platformPlugins = com.github.gtache.lsp:1.6.1
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11

--- a/src/main/kotlin/com/influxdata/intellijflux/FluxPreloadingActivity.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/FluxPreloadingActivity.kt
@@ -1,0 +1,21 @@
+package com.influxdata.intellijflux
+
+import com.github.gtache.lsp.client.languageserver.serverdefinition.ExeLanguageServerDefinition
+import com.github.gtache.lsp.client.languageserver.serverdefinition.LanguageServerDefinition
+import com.intellij.openapi.application.PreloadingActivity
+import com.intellij.openapi.progress.ProgressIndicator
+
+class FluxPreloadingActivity : PreloadingActivity() {
+    override fun preload(indicator: ProgressIndicator) {
+        LanguageServerDefinition.register(
+            ExeLanguageServerDefinition(
+                "flux",
+                // FIXME: read from settings instead of hard-coding (requiring the bin to be in PATH).
+                //  A wrinkle is we'd need a way to re-register the server
+                //  definition when the settings change.
+                "flux-lsp",
+                arrayOf()
+            )
+        )
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,6 +6,7 @@
     <vendor>InfluxData</vendor>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends>com.github.gtache.lsp</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.influxdata.intellijflux.services.MyApplicationService"/>
@@ -14,6 +15,9 @@
                   implementationClass="com.influxdata.intellijflux.language.FluxFileType"
                   language="Flux"
                   extensions="flux"/>
+        <preloadingActivity
+                implementation="com.influxdata.intellijflux.FluxPreloadingActivity"
+                id="com.influxdata.intellijflux.FluxPreloadingActivity"/>
     </extensions>
 
     <applicationListeners>


### PR DESCRIPTION
Using the pre-existing LSP Support plugin, pre-configure `flux-lsp` on startup, watching for `.flux` sources in the project tree.

There's currently no configuration for the path to the flux-lsp binary; the plugin expects to be find it in the `PATH`.

Today, the flux-lsp binary can be installed using `cargo`, see https://github.com/influxdata/flux-lsp#installing-command-line-server for details.

> N.b. you can install cargo binaries from git repos on your local disk using a `file://` protocol URL, which makes for easier hacking on a combination of the LSP itself and/or this plugin.
>
> Additionally note that installing via cargo will generally place the binary under `$CARGO_HOME/.bin` which is typically added to your `PATH` via shell customization. This means in many cases the IDE won't be able to find it. As a workaround I symlinked the binary to `~/.local/bin` which is in the system default `PATH`.