### PR TITLE
feat: Allow flux-lsp path to be configured via settings

### DIFF
--- a/src/main/kotlin/com/influxdata/intellijflux/settings/AppSettingsComponent.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/settings/AppSettingsComponent.kt
@@ -1,0 +1,31 @@
+package com.influxdata.intellijflux.settings
+
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBTextField
+import com.intellij.util.ui.FormBuilder
+import org.jetbrains.annotations.NotNull
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+
+class AppSettingsComponent {
+    val panel: JPanel
+    private val lspPathField = JBTextField("flux-lsp")
+
+    init {
+        panel = FormBuilder.createFormBuilder()
+            .addLabeledComponent(JBLabel("Enter path to flux-lsp: "), lspPathField, 1, false)
+            .addComponentFillVertically(JPanel(), 0)
+            .panel
+    }
+
+    val preferredFocusedComponent: JComponent
+        get() = lspPathField
+
+    @get:NotNull
+    var lspPath: String?
+        get() = lspPathField.text
+        set(newText) {
+            lspPathField.text = newText
+        }
+}

--- a/src/main/kotlin/com/influxdata/intellijflux/settings/AppSettingsConfigurable.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/settings/AppSettingsConfigurable.kt
@@ -1,0 +1,41 @@
+package com.influxdata.intellijflux.settings
+
+import com.intellij.openapi.options.Configurable
+import javax.swing.JComponent
+
+class AppSettingsConfigurable : Configurable {
+    private var settingsComponent: AppSettingsComponent? = null
+
+    override fun getDisplayName(): String {
+        return "Flux Language"
+    }
+
+    override fun getPreferredFocusedComponent(): JComponent {
+        return settingsComponent!!.preferredFocusedComponent
+    }
+
+    override fun createComponent(): JComponent {
+        settingsComponent = AppSettingsComponent()
+        return settingsComponent!!.panel
+    }
+
+    override fun isModified(): Boolean {
+        val settings = AppSettingsState.instance
+        return settingsComponent?.lspPath != settings.lspPath
+    }
+
+    override fun apply() {
+        val settings = AppSettingsState.instance
+        settings.lspPath = settingsComponent?.lspPath.orEmpty()
+    }
+
+    override fun reset() {
+        val settings = AppSettingsState.instance
+        settingsComponent?.lspPath = settings.lspPath
+    }
+
+    override fun disposeUIResources() {
+        settingsComponent = null
+    }
+
+}

--- a/src/main/kotlin/com/influxdata/intellijflux/settings/AppSettingsState.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/settings/AppSettingsState.kt
@@ -1,0 +1,32 @@
+package com.influxdata.intellijflux.settings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+import org.jetbrains.annotations.NotNull
+import org.jetbrains.annotations.Nullable
+
+
+@State(
+    name = "com.influxdata.intellijflux.settings.AppSettingsState",
+    storages = [Storage("FluxPluginAppSettings.xml")]
+)
+class AppSettingsState : PersistentStateComponent<AppSettingsState> {
+    var lspPath = "flux-lsp"
+
+    @Nullable
+    override fun getState(): AppSettingsState {
+        return this
+    }
+
+    override fun loadState(@NotNull state: AppSettingsState) {
+        XmlSerializerUtil.copyBean(state, this)
+    }
+
+    companion object {
+        val instance: AppSettingsState
+            get() = ApplicationManager.getApplication().getService(AppSettingsState::class.java)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,6 +18,11 @@
         <preloadingActivity
                 implementation="com.influxdata.intellijflux.FluxPreloadingActivity"
                 id="com.influxdata.intellijflux.FluxPreloadingActivity"/>
+
+        <applicationService serviceImplementation="com.influxdata.intellijflux.settings.AppSettingsState"/>
+        <applicationConfigurable parentId="tools" instance="com.influxdata.intellijflux.settings.AppSettingsConfigurable"
+                                 id="com.influxdata.intellijflux.settings.AppSettingsConfigurable"
+                                 displayName="Flux Language"/>
     </extensions>
 
     <applicationListeners>


### PR DESCRIPTION
WIP...

The value in the settings panel is persisted and loaded from disk correctly, but still todo:

- [ ] read the settings value when registering the LSP.
- [ ] reload the LSP when the settings change.
- [x] rebase when #3 merges.
- [ ] (stretch goal) update the form to use one of those file picker browser dialogue.