### PR TITLE
refactor: switch to ballerina

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,14 @@ version = properties("pluginVersion")
 // Configure project's dependencies
 repositories {
     mavenCentral()
+    maven {
+        url = uri("https://jitpack.io")
+    }
+}
+
+dependencies {
+    implementation("com.github.ballerina-platform:lsp4intellij:0.94.2")
+//    implementation("com.github.ballerina-platform:lsp4intellij:master-SNAPSHOT")
 }
 
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ platformVersion = 2020.3.4
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.github.gtache.lsp:1.6.1
+platformPlugins =
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11

--- a/src/main/kotlin/com/influxdata/intellijflux/FluxPreloadingActivity.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/FluxPreloadingActivity.kt
@@ -1,20 +1,19 @@
 package com.influxdata.intellijflux
 
-import com.github.gtache.lsp.client.languageserver.serverdefinition.ExeLanguageServerDefinition
-import com.github.gtache.lsp.client.languageserver.serverdefinition.LanguageServerDefinition
 import com.intellij.openapi.application.PreloadingActivity
 import com.intellij.openapi.progress.ProgressIndicator
+import org.wso2.lsp4intellij.IntellijLanguageClient
+import org.wso2.lsp4intellij.client.languageserver.serverdefinition.RawCommandServerDefinition
 
 class FluxPreloadingActivity : PreloadingActivity() {
     override fun preload(indicator: ProgressIndicator) {
-        LanguageServerDefinition.register(
-            ExeLanguageServerDefinition(
+        IntellijLanguageClient.addServerDefinition(
+            RawCommandServerDefinition(
                 "flux",
                 // FIXME: read from settings instead of hard-coding (requiring the bin to be in PATH).
                 //  A wrinkle is we'd need a way to re-register the server
                 //  definition when the settings change.
-                "flux-lsp",
-                arrayOf()
+                arrayOf("flux-lsp", "--log-file", ".flux-lsp.log"),
             )
         )
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -6,8 +6,11 @@
     <vendor>InfluxData</vendor>
 
     <depends>com.intellij.modules.platform</depends>
-    <depends>com.github.gtache.lsp</depends>
-
+    <application-components>
+        <component>
+            <implementation-class>org.wso2.lsp4intellij.IntellijLanguageClient</implementation-class>
+        </component>
+    </application-components>
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.influxdata.intellijflux.services.MyApplicationService"/>
         <projectService serviceImplementation="com.influxdata.intellijflux.services.MyProjectService"/>
@@ -15,10 +18,37 @@
                   implementationClass="com.influxdata.intellijflux.language.FluxFileType"
                   language="Flux"
                   extensions="flux"/>
+
+
         <preloadingActivity
                 implementation="com.influxdata.intellijflux.FluxPreloadingActivity"
                 id="com.influxdata.intellijflux.FluxPreloadingActivity"/>
+
+
+        <completion.contributor implementationClass="org.wso2.lsp4intellij.contributors.LSPCompletionContributor"
+                                id="LSPCompletionContributor" language="any"/>
+        <externalAnnotator id="LSPAnnotator" language="Flux"
+                           implementationClass="org.wso2.lsp4intellij.contributors.annotator.LSPAnnotator"/>
+        <gotoSymbolContributor implementation="org.wso2.lsp4intellij.contributors.symbol.LSPSymbolContributor"
+                               id="LSPSymbolContributor"/>
+
+        <renameHandler implementation="org.wso2.lsp4intellij.contributors.rename.LSPRenameHandler"
+                       id="LSPRenameHandler" order="first"/>
+        <renamePsiElementProcessor implementation="org.wso2.lsp4intellij.contributors.rename.LSPRenameProcessor"
+                                   id="LSPRenameProcessor" order="first"/>
+        <typedHandler implementation="org.wso2.lsp4intellij.listeners.LSPTypedHandler"
+                      id="LSPTypedHandler"/>
+
     </extensions>
+
+    <actions>
+        <!-- Reformat doesn't appear to work... -->
+        <action class="org.wso2.lsp4intellij.actions.LSPReformatAction" id="ReformatCode" use-shortcut-of="ReformatCode"
+                overrides="true" text="Reformat Code"/>
+        <action class="org.wso2.lsp4intellij.actions.LSPShowReformatDialogAction" id="ShowReformatFileDialog"
+                use-shortcut-of="ShowReformatFileDialog" overrides="true" text="Show Reformat File Dialog"/>
+    </actions>
+
 
     <applicationListeners>
         <listener class="com.influxdata.intellijflux.listeners.MyProjectManagerListener"


### PR DESCRIPTION
The lsp (gtache) plugin we based ours on crashed often when a flux source
was invalid (failing type checks) and then, while in that state, the editor
asks the LSP for completion or signature info.

This diff switches us to depend on the "ballerina" LSP library which is
effectively a fork of the original plugin we tried to use.

"Ballerina" still has issues in similar situations, but is a little more
recoverable. If the editor gets in a bad state and stops offering
completions, closing and opening the buffer again will usually get it
going again.

While code reformatting didn't work at all with the gtache plugin, it
ALSO doesn't work here with ballerina. It appears the support is there,
but the config (in plugin.xml) may be outdated for the current intellij
platform.

---

N.b. the instructions for configuring the lib in the current master
branch README are incorrect. I had to refer to the README from the
0.94.2 tag to get this all wired up.