### PR TITLE
feat: grammar-kit based parser

### DIFF
--- a/src/main/kotlin/com/influxdata/intellijflux/language/Flux.bnf
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/Flux.bnf
@@ -41,7 +41,7 @@
     ]
 //    name(".*_op")='operartor'
     name(".*Expr")='expression'
-//    extends(".*Expr")=expr
+    extends(".*Expr")=Expression
 }
 
 root ::= root_item *
@@ -59,8 +59,9 @@ private root_item ::=
     | option
     | Expression
 
-// FIXME: need to figure out how to model member access - `pkg.ident`
 identifier ::= letter (letter | unicode_digit)*
+// Specifically targeting `pkg.ident` use cases... not arbitrary member expressions.
+qualified_ident ::= identifier token_sep? DOT token_sep? (identifier | qualified_ident) {extends=identifier}
 
 decimal_digit ::= "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
 
@@ -88,11 +89,17 @@ second ::= decimal_digit decimal_digit
 fractional_second ::= "."  decimal_digit+
 time_offset ::= "Z" | ("+" | "-") hour ":" minute
 
-option ::= "option" identifier token_sep? EQ token_sep? ValueExpr
+option ::= "option" token_sep? AssignmentExpr
 
-Expression ::= AssignmentExpr | PipeExpr | ValueExpr
+Expression ::=
+    AssignmentExpr
+    | FuncExpr
+    | CallExpr
+    | CompositeExpr
+    | LiteralExpr
+    | IdentExpr
+    | PipeExpr
 
-ValueExpr ::= FuncExpr | CallExpr | CompositeExpr | LiteralExpr | identifier
 LiteralExpr ::=
     float_lit
     | date_time_lit
@@ -102,20 +109,22 @@ LiteralExpr ::=
     | regex_lit
 
 
+// TODO: Label?
+IdentExpr ::= qualified_ident | identifier
 CallExpr ::= identifier token_sep? LP token_sep? [param_list] token_sep? RP
-param_list ::= identifier token_sep? COL token_sep? ValueExpr token_sep? ["," token_sep? param_list?]
-AssignmentExpr ::= identifier token_sep? EQ token_sep? ValueExpr
+param_list ::= identifier token_sep? COL token_sep? Expression token_sep? ["," token_sep? param_list?]
 FuncExpr ::= LP token_sep? param_list? RP token_sep? ARROW token_sep? fn_body
-fn_body ::= ValueExpr // FIXME: needs to model blocks, parens, the `return` kw....
+fn_body ::= Expression // FIXME: needs to model blocks, parens, the `return` kw....
+// XXX: should the LHS be an IdentExpr?
+AssignmentExpr ::= IdentExpr token_sep? EQ token_sep? Expression
 
 CompositeExpr ::= record_lit
 record_lit ::= LB token_sep? param_list token_sep? RB
 
 // a |> b |> c ...
-// FIXME: fails to parse recursive -- bails at 2nd pipe forward
 PipeExpr ::=
-    ValueExpr
+    Expression
     token_sep?
     PIPE_FORWARD
     token_sep?
-    (ValueExpr | PIPE_FORWARD token_sep? PipeExpr)
+    Expression {rightAssociative=true}

--- a/src/main/kotlin/com/influxdata/intellijflux/language/Flux.bnf
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/Flux.bnf
@@ -1,0 +1,20 @@
+{
+  parserClass="com.influxdata.intellijflux.language.parser.FluxParser"
+
+  extends="com.intellij.extapi.psi.ASTWrapperPsiElement"
+
+  psiClassPrefix="Simple"
+  psiImplClassSuffix="Impl"
+  psiPackage="com.influxdata.intellijflux.language.psi"
+  psiImplPackage="com.influxdata.intellijflux.language.psi.impl"
+
+  elementTypeHolderClass="com.influxdata.intellijflux.language.psi.FluxTypes"
+  elementTypeClass="com.influxdata.intellijflux.language.psi.FluxElementType"
+  tokenTypeClass="com.influxdata.intellijflux.language.psi.FluxTokenType"
+}
+
+simpleFile ::= item_*
+
+private item_ ::= (property|COMMENT|CRLF)
+
+property ::= (KEY? SEPARATOR VALUE?) | KEY

--- a/src/main/kotlin/com/influxdata/intellijflux/language/Flux.bnf
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/Flux.bnf
@@ -1,20 +1,86 @@
 {
-  parserClass="com.influxdata.intellijflux.language.parser.FluxParser"
+    parserClass="com.influxdata.intellijflux.language.parser.FluxParser"
+    parserUtilClass="com.influxdata.intellijflux.language.FluxParserUtil"
+    extends="com.intellij.extapi.psi.ASTWrapperPsiElement"
 
-  extends="com.intellij.extapi.psi.ASTWrapperPsiElement"
+    psiClassPrefix="Flux"
+    psiImplClassSuffix="Impl"
+    psiPackage="com.influxdata.intellijflux.language.psi"
+    psiImplPackage="com.influxdata.intellijflux.language.psi.impl"
 
-  psiClassPrefix="Simple"
-  psiImplClassSuffix="Impl"
-  psiPackage="com.influxdata.intellijflux.language.psi"
-  psiImplPackage="com.influxdata.intellijflux.language.psi.impl"
+    elementTypeHolderClass="com.influxdata.intellijflux.language.psi.FluxTypes"
+    elementTypeClass="com.influxdata.intellijflux.language.psi.FluxElementType"
+    tokenTypeClass="com.influxdata.intellijflux.language.psi.FluxTokenType"
 
-  elementTypeHolderClass="com.influxdata.intellijflux.language.psi.FluxTypes"
-  elementTypeClass="com.influxdata.intellijflux.language.psi.FluxElementType"
-  tokenTypeClass="com.influxdata.intellijflux.language.psi.FluxTokenType"
+    tokens=[
+        comment='regexp://.*'
+        // FIXME: figure out how to suppress this rule from generating nodes
+        // FIXME: spec only names \n as the linesep -- what about \r\n and \r?
+        space='regexp:(\r\n|\r|\n|\s)+'
+
+        COL=':'
+        SEMI=';'
+        EQ='='
+        LP='('
+        RP=')'
+        DOT='.'
+        BACKSLASH='\'
+
+        // FIXME: less detailed than the flux spec. Just looks for anything falling between two unescaped double quotes.
+        string_lit='regexp:"([^"\\]|\\.)*"'
+        // FIXME: less detailed than the flux spec. Just looks for anything falling between two unescaped slashes.
+        regex_lit='regexp:/([^/\\]|\\.)*/'
+        unicode_digit="regexp:\p{N}"
+        letter="regexp:(\p{L}|_)"
+
+        plus_op='+'
+        minus_op='-'
+        mult_op='*'
+        div_op='/'
+        bang_op='!'
+    ]
+    name(".*_op")='operartor'
+    name(".*_expr")='expression'
+    extends(".*_expr")=expr
 }
 
-simpleFile ::= item_*
+root ::= root_item *
 
-private item_ ::= (property|COMMENT|CRLF)
+private external EOF ::= <<eof>>
 
-property ::= (KEY? SEPARATOR VALUE?) | KEY
+private root_item ::=
+    !EOF space
+    | string_lit
+    | float_lit
+    | date_time_lit
+    | duration_lit
+    | int_lit
+    | identifier
+
+identifier ::= letter (letter | unicode_digit)*
+
+decimal_digit ::= "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+
+private nonzero_decimal_digit ::= !"0" decimal_digit
+int_lit ::= "0" | nonzero_decimal_digit decimal_digit*
+
+float_lit ::= decimals DOT decimals? | DOT decimals
+decimals ::= decimal_digit+
+
+
+duration_lit  ::= (duration_magnitude duration_unit)+
+duration_magnitude ::= decimal_digit+
+duration_unit ::= "y" | "mo" | "w" | "d" | "h" | "m" | "s" | "ms" | "us" | "µs" | "ns"
+
+
+date_time_lit ::= date [ "T" time ]
+date ::= year_lit "-" month "-" day
+year_lit ::= decimal_digit decimal_digit decimal_digit decimal_digit
+month ::= decimal_digit decimal_digit
+day ::= decimal_digit decimal_digit
+time ::= hour ":" minute ":" second [ fractional_second ] [ time_offset ]
+hour ::= decimal_digit decimal_digit
+minute ::= decimal_digit decimal_digit
+second ::= decimal_digit decimal_digit
+fractional_second ::= "."  decimal_digit+
+time_offset ::= "Z" | ("+" | "-") hour ":" minute

--- a/src/main/kotlin/com/influxdata/intellijflux/language/Flux.bnf
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/Flux.bnf
@@ -13,69 +13,95 @@
     tokenTypeClass="com.influxdata.intellijflux.language.psi.FluxTokenType"
 
     tokens=[
-        comment='regexp://.*(\n)?'
-        space='regexp:(\s|\n)+'
-        COL=':'
-        SEMI=';'
-        EQ='='
-        LP='('
-        RP=')'
-        LB='{'
-        RB='}'
-        DOT='.'
-        ARROW="=>"
-        PIPE_FORWARD="|>"
 
-        // FIXME: less detailed than the flux spec. Just looks for anything falling between two unescaped double quotes.
+        // XXX: less detailed than the flux spec. Just looks for anything falling between two unescaped double quotes.
         string_lit='regexp:"([^"\\]|\\.)*"'
-        // FIXME: less detailed than the flux spec. Just looks for anything falling between two unescaped slashes.
-        regex_lit='regexp:/([^/\\]|\\.)*/'
-        unicode_digit="regexp:\p{N}"
-        letter="regexp:(\p{L}|_)"
+        // XXX: less detailed than the flux spec. Just looks for anything falling between two slashes on the same line.
+        regex_lit='regexp:/[^\n]+/'
+        id="regexp:[\p{L}_][\p{L}\p{N}_]*"
 
-        plus_op='+'
-        minus_op='-'
-        mult_op='*'
-        div_op='/'
-        bang_op='!'
+        line_comment='regexp://.*(\n)?'
+        // Both needed to get tokens to split correctly...
+        // The `space_` token should not be referenced in the grammar else it
+        // won't work properly.
+        // The `space` token is used to drive the `EmptyStatement` which
+        // apparently is also required to get things splitting nicely.
+        space_=' '
+        space='regexp:(\s|\n|//.*(\n)?)+'
     ]
-//    name(".*_op")='operartor'
-    name(".*Expr")='expression'
-    extends(".*Expr")=Expression
+    name(".*Expression")='expression'
+    extends(".*Expression")=ExpressionStatement
+    extends(".*Statement")=Statement
+    extends(".*(Literal|_lit)")=ExpressionStatement
 }
 
-root ::= root_item *
+File ::=
+    [ PackageClause ]
+    [ ImportList ]
+    StatementList
 
+identifier ::= id
+
+EmptyStatement ::= space
+ImportList ::= ImportDeclaration+
+PackageClause ::= "package" space? identifier
+ImportDeclaration ::= "import" [space? identifier] space? string_lit
+ReturnStatement ::= "return" space Expression
+ExpressionStatement ::= Expression
+StatementList ::= !<<EOF>> Statement* {pin=2 recoverWhile=stmt_recover}
+Statement ::=
+    BuiltinStatement
+    | OptionAssignment
+    | VariableAssignment
+    | ReturnStatement
+    | ExpressionStatement
+    | EmptyStatement
+
+private stmt_recover ::= !space
+
+
+
+VariableAssignment ::= identifier "=" Expression {extends=Statement}
+OptionAssignment ::= "option" [identifier "."] VariableAssignment {extends=Statement}
+
+Block ::= "{" space? StatementList space? "}"
+
+BuiltinStatement ::= "builtin" space identifier space? ":" space? Signature
+Signature ::= MonoType [space? "where" space? Constraints]
+MonoType ::= Tvar | Basic | Array | Record | Function
+Basic ::= "int" | "uint" | "float" | "string" | "bool" | "time" | "duration" | "bytes" | "regexp"
+Array ::= "[" space? MonoType space? "]"
+Record ::= ( "{" space? [TProperties] space? "}" ) | ( "{" space? Tvar space? "with" space? TProperties space? "}" )
+Function ::= "(" space? [Parameters] space? ")" space? "=>" space? MonoType
+Tvar ::=
+    "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J" | "K" | "L" | "M"
+    | "N" | "O" | "P" | "Q" | "R" | "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z"
+
+TProperties ::= <<list TProperty>>
+TProperty ::= Label space? ":" space? MonoType
+Label ::= identifier | string_lit
+
+Parameters ::= <<list Parameter>>
+Parameter ::= [("<-" | "?") space? ] identifier space? ":" space? MonoType
+
+Constraints ::= <<list Constraint>>
+Constraint ::= Tvar space? ":" space? Kinds
+Kinds ::= identifier space? ("+" space? identifier)*
+
+private meta list ::= <<p>> space? ("," space? <<p>> space?)* ","?
 private external EOF ::= <<eof>>
-// token_sep is a workaround for handling comments that appear inside other
-// larger structures.
-// Ex: comments at the end of a line inside a line-separated parameter list or
-// record fields.
-private token_sep ::= (space | comment)+
 
-private root_item ::=
-    !EOF
-    token_sep
-    | option
-    | Expression
-
-identifier ::= letter (letter | unicode_digit)*
-// Specifically targeting `pkg.ident` use cases... not arbitrary member expressions.
-qualified_ident ::= identifier token_sep? DOT token_sep? (identifier | qualified_ident) {extends=identifier}
-
+// Literals
 decimal_digit ::= "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
-
 private nonzero_decimal_digit ::= !"0" decimal_digit
 int_lit ::= "0" | nonzero_decimal_digit decimal_digit*
 
-float_lit ::= decimals DOT decimals? | DOT decimals
+float_lit ::= decimals "." decimals? | "." decimals
 decimals ::= decimal_digit+
-
 
 duration_lit  ::= (duration_magnitude duration_unit)+
 duration_magnitude ::= decimal_digit+
 duration_unit ::= "y" | "mo" | "w" | "d" | "h" | "m" | "s" | "ms" | "us" | "µs" | "ns"
-
 
 date_time_lit ::= date [ "T" time ]
 date ::= year_lit "-" month "-" day
@@ -89,42 +115,99 @@ second ::= decimal_digit decimal_digit
 fractional_second ::= "."  decimal_digit+
 time_offset ::= "Z" | ("+" | "-") hour ":" minute
 
-option ::= "option" token_sep? AssignmentExpr
 
-Expression ::=
-    AssignmentExpr
-    | FuncExpr
-    | CallExpr
-    | CompositeExpr
-    | LiteralExpr
-    | IdentExpr
-    | PipeExpr
+FunctionLiteral ::= fn_params space? "=>" space? fn_body
+fn_params ::= "(" space? [ fn_param_list space? ] ")"
+fn_param_list ::= <<list fn_param>>
+fn_param ::= identifier [ space? "=" space? Expression ]
+fn_body ::= Expression | Block
 
-LiteralExpr ::=
-    float_lit
-    | date_time_lit
-    | duration_lit
-    | int_lit
-    | string_lit
+RecordLiteral ::= "{" space? RecordBody space? "}"
+RecordBody ::= WithProperties | PropertyList
+WithProperties ::= identifier space? "with" space? PropertyList
+PropertyList ::= <<list Property>>
+Property ::=
+    identifier [ space? ":" space? Expression ]
+    | string_lit space? ":" space? Expression
+
+ArrayLiteral ::= "[" space? ExpressionList space? "]"
+ExpressionList ::= [ <<list Expression>> ]
+
+DictLiteral ::= EmptyDict | "[" space? AssociativeList space? "]"
+EmptyDict ::= "[" space? ":" space? "]"
+AssociativeList ::= <<list Association>>
+Association ::= Expression space? ":" space? Expression
+
+pipe_receive_lit ::= "<-"
+
+Literal ::=
+    FunctionLiteral
+    | DictLiteral
+    | ArrayLiteral
+    | RecordLiteral
     | regex_lit
+    | string_lit
+    | pipe_receive_lit
+    | duration_lit
+    | date_time_lit
+    | float_lit
+    | int_lit
+
+// Expressions
+private Expression ::=
+    PostfixExpression
+    | PipeExpression
+    | ExponentExpression
+    | MultiplicativeExpression
+    | AdditiveExpression
+    | ComparisonExpression
+    | UnaryExpression
+    | IndexExpression
+    | LogicalExpression
+    | ConditionalExpression
+    | MemberExpression
+    | CallExpression
+    | PrimaryExpression
 
 
-// TODO: Label?
-IdentExpr ::= qualified_ident | identifier
-CallExpr ::= identifier token_sep? LP token_sep? [param_list] token_sep? RP
-param_list ::= identifier token_sep? COL token_sep? Expression token_sep? ["," token_sep? param_list?]
-FuncExpr ::= LP token_sep? param_list? RP token_sep? ARROW token_sep? fn_body
-fn_body ::= Expression // FIXME: needs to model blocks, parens, the `return` kw....
-// XXX: should the LHS be an IdentExpr?
-AssignmentExpr ::= IdentExpr token_sep? EQ token_sep? Expression
+PrimaryExpression ::= Literal | "(" space? Expression space? ")" | identifier
+CallExpression ::= "(" space? [PropertyList] space? ")"
+IndexExpression ::= "[" space? Expression space? "]"
+MemberExpression ::= DotExpression | MemberBracketExpression
+DotExpression ::= "." space? identifer
+MemberBracketExpression ::= "[" space? string_lit space? "]"
 
-CompositeExpr ::= record_lit
-record_lit ::= LB token_sep? param_list token_sep? RB
-
-// a |> b |> c ...
-PipeExpr ::=
-    Expression
-    token_sep?
-    PIPE_FORWARD
-    token_sep?
-    Expression {rightAssociative=true}
+// Operators etc
+ConditionalExpression       ::= LogicalExpression
+                            | "if" space? Expression space? "then" space? Expression space? "else" space? Expression
+LogicalExpression           ::= UnaryLogicalExpression
+                            | LogicalExpression space? LogicalOperator space? UnaryLogicalExpression
+LogicalOperator             ::= "and" | "or"
+UnaryLogicalExpression      ::= ComparisonExpression
+                            | UnaryLogicalOperator space? UnaryLogicalExpression
+UnaryLogicalOperator        ::= "not" | "exists"
+ComparisonExpression        ::= MultiplicativeExpression
+                            | ComparisonExpression space? ComparisonOperator space? MultiplicativeExpression
+ComparisonOperator          ::= "==" | "!=" | "<" | "<=" | ">" | ">=" | "=~" | "!~"
+AdditiveExpression          ::= MultiplicativeExpression
+                            | AdditiveExpression space? AdditiveOperator space? MultiplicativeExpression
+AdditiveOperator            ::= "+" | "-"
+// XXX: in spec, alternate showed ExponentOperator while MultiplicativeOperator
+// was unused. Guessing it should go here.
+MultiplicativeExpression    ::= ExponentExpression
+                            | ExponentExpression space? MultiplicativeOperator space? MultiplicativeExpression
+MultiplicativeOperator      ::= "*" | "/" | "%"
+ExponentExpression          ::= PipeExpression
+                            | ExponentExpression space? ExponentOperator space? PipeExpression
+ExponentOperator            ::= "^"
+PipeExpression              ::= PostfixExpression
+                            | PipeExpression space? PipeOperator space? UnaryExpression
+PipeOperator                ::= "|>"
+UnaryExpression             ::= PostfixExpression
+                            | PrefixOperator space? UnaryExpression
+PrefixOperator              ::= "+" | "-"
+PostfixExpression           ::= PrimaryExpression
+                            | PostfixExpression space? PostfixOperator
+PostfixOperator             ::= MemberExpression
+                            | CallExpression
+                            | IndexExpression

--- a/src/main/kotlin/com/influxdata/intellijflux/language/Flux.bnf
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/Flux.bnf
@@ -13,18 +13,18 @@
     tokenTypeClass="com.influxdata.intellijflux.language.psi.FluxTokenType"
 
     tokens=[
-        comment='regexp://.*'
-        // FIXME: figure out how to suppress this rule from generating nodes
-        // FIXME: spec only names \n as the linesep -- what about \r\n and \r?
-        space='regexp:(\r\n|\r|\n|\s)+'
-
+        comment='regexp://.*(\n)?'
+        space='regexp:(\s|\n)+'
         COL=':'
         SEMI=';'
         EQ='='
         LP='('
         RP=')'
+        LB='{'
+        RB='}'
         DOT='.'
-        BACKSLASH='\'
+        ARROW="=>"
+        PIPE_FORWARD="|>"
 
         // FIXME: less detailed than the flux spec. Just looks for anything falling between two unescaped double quotes.
         string_lit='regexp:"([^"\\]|\\.)*"'
@@ -39,24 +39,27 @@
         div_op='/'
         bang_op='!'
     ]
-    name(".*_op")='operartor'
-    name(".*_expr")='expression'
-    extends(".*_expr")=expr
+//    name(".*_op")='operartor'
+    name(".*Expr")='expression'
+//    extends(".*Expr")=expr
 }
 
 root ::= root_item *
 
 private external EOF ::= <<eof>>
+// token_sep is a workaround for handling comments that appear inside other
+// larger structures.
+// Ex: comments at the end of a line inside a line-separated parameter list or
+// record fields.
+private token_sep ::= (space | comment)+
 
 private root_item ::=
-    !EOF space
-    | string_lit
-    | float_lit
-    | date_time_lit
-    | duration_lit
-    | int_lit
-    | identifier
+    !EOF
+    token_sep
+    | option
+    | Expression
 
+// FIXME: need to figure out how to model member access - `pkg.ident`
 identifier ::= letter (letter | unicode_digit)*
 
 decimal_digit ::= "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
@@ -84,3 +87,35 @@ minute ::= decimal_digit decimal_digit
 second ::= decimal_digit decimal_digit
 fractional_second ::= "."  decimal_digit+
 time_offset ::= "Z" | ("+" | "-") hour ":" minute
+
+option ::= "option" identifier token_sep? EQ token_sep? ValueExpr
+
+Expression ::= AssignmentExpr | PipeExpr | ValueExpr
+
+ValueExpr ::= FuncExpr | CallExpr | CompositeExpr | LiteralExpr | identifier
+LiteralExpr ::=
+    float_lit
+    | date_time_lit
+    | duration_lit
+    | int_lit
+    | string_lit
+    | regex_lit
+
+
+CallExpr ::= identifier token_sep? LP token_sep? [param_list] token_sep? RP
+param_list ::= identifier token_sep? COL token_sep? ValueExpr token_sep? ["," token_sep? param_list?]
+AssignmentExpr ::= identifier token_sep? EQ token_sep? ValueExpr
+FuncExpr ::= LP token_sep? param_list? RP token_sep? ARROW token_sep? fn_body
+fn_body ::= ValueExpr // FIXME: needs to model blocks, parens, the `return` kw....
+
+CompositeExpr ::= record_lit
+record_lit ::= LB token_sep? param_list token_sep? RB
+
+// a |> b |> c ...
+// FIXME: fails to parse recursive -- bails at 2nd pipe forward
+PipeExpr ::=
+    ValueExpr
+    token_sep?
+    PIPE_FORWARD
+    token_sep?
+    (ValueExpr | PIPE_FORWARD token_sep? PipeExpr)

--- a/src/main/kotlin/com/influxdata/intellijflux/language/FluxFileType.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/FluxFileType.kt
@@ -2,7 +2,7 @@ package com.influxdata.intellijflux.language
 
 import com.intellij.openapi.fileTypes.LanguageFileType
 
-object FluxFileType : LanguageFileType(FluxLanguage) {
+object FluxFileType : LanguageFileType(FluxLanguage.INSTANCE) {
     override fun getName() = "Flux file"
 
     override fun getDescription() = "Flux language file"

--- a/src/main/kotlin/com/influxdata/intellijflux/language/FluxLanguage.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/FluxLanguage.kt
@@ -2,5 +2,8 @@ package com.influxdata.intellijflux.language
 
 import com.intellij.lang.Language
 
-object FluxLanguage : Language("Flux") {
+class FluxLanguage : Language("Flux") {
+    companion object {
+        val INSTANCE = FluxLanguage()
+    }
 }

--- a/src/main/kotlin/com/influxdata/intellijflux/language/FluxParserUtil.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/FluxParserUtil.kt
@@ -1,0 +1,25 @@
+package com.influxdata.intellijflux.language
+
+import com.intellij.lang.PsiBuilder
+
+
+// FIXME: maybe we can leverage the rust parser here?
+
+class FluxParserUtil {
+
+    fun isHexDigit(builder: PsiBuilder, level: Int): Boolean {
+        return false
+    }
+
+    fun isUnicodeChar(builder: PsiBuilder, level: Int): Boolean {
+        return false
+    }
+
+    fun isLetter(builder: PsiBuilder, level: Int): Boolean {
+        return false
+    }
+
+    fun eof(builder: PsiBuilder, level: Int): Boolean {
+        return builder.eof()
+    }
+}

--- a/src/main/kotlin/com/influxdata/intellijflux/language/psi/FluxElementType.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/psi/FluxElementType.kt
@@ -1,0 +1,8 @@
+package com.influxdata.intellijflux.language.psi
+
+import com.influxdata.intellijflux.language.FluxLanguage
+import com.intellij.psi.tree.IElementType
+import org.jetbrains.annotations.NonNls
+
+class FluxElementType(debugName: @NonNls String) :
+    IElementType(debugName, FluxLanguage.INSTANCE)

--- a/src/main/kotlin/com/influxdata/intellijflux/language/psi/FluxTokenType.kt
+++ b/src/main/kotlin/com/influxdata/intellijflux/language/psi/FluxTokenType.kt
@@ -1,0 +1,13 @@
+package com.influxdata.intellijflux.language.psi
+
+import com.influxdata.intellijflux.language.FluxLanguage
+import com.intellij.psi.tree.IElementType
+import org.jetbrains.annotations.NonNls
+
+
+class FluxTokenType(debugName: @NonNls String) :
+    IElementType(debugName, FluxLanguage.INSTANCE) {
+    override fun toString(): String {
+        return "FluxTokenType." + super.toString()
+    }
+}


### PR DESCRIPTION
Mostly just trying to capture some notes, lessons learned, during my afternoon hacking for JOIN 2022. This PR will not likely be _good to merge_ without a lot more work.

It might be quite a while until we loop back to this effort so I'm just looking to brain dump before the thoughts all hit "cold storage."

Mostly my efforts fell short. Like Edison, I explored all the ways to _not make a light bulb_. 

![Crispin Glover as Edison in Drunk History](https://user-images.githubusercontent.com/301388/167496712-d2b75833-8957-4562-a08b-dcd57a18ea15.png)


## Workflow

The grammar-kit intellij plugin has a "live preview" mode which is the prescribed method for early iterations of a grammar.

It pops open a buffer which you can put text to use as input to the parser. The structure pane will list out the parser's output.

![Screenshot of IntelliJ with the Grammar-kit plugin preview pane and structure pane on display](https://user-images.githubusercontent.com/301388/167497332-169bbdc6-a0df-46c9-98f3-6dff880d3076.png)


This is the flux code I used, cobbled together from the numerous examples in the flux spec:

https://gist.github.com/onelson/f4610e7deaa18f3bbd3d5e7d906508d5


## Problems

This section aims to _nutshell_ some of the difficulties I experienced. 


### Unicode/Character ranges

Many parts of the flux spec describe subsets of the unicode table, such as `Letter`, `Number`, but also being able to match arbitrary codepoints (aka "bytes").

The grammar-kit BNF-style DSL doesn't really provide any convenient way to match character ranges or families, other than to define **global tokens** via a **regex-based** rule.

The regex-based global tokens tend to be problematic since they run with hard-to-control priority, and will tend to match _once only_. This is to say, overlapping patterns cannot be reliably defined. For example, a unicode `Letter` codepoint is also _just a codepoint_ which should be appropriately considered a "byte" but global tokens will wind up as one or the other, and sometimes they will be parsed as _not the one your producer expects_.


Instead of relying on global tokens to define these regex, I think we should be delegating to a -ParseUtil class. I have stubbed one as `FluxParserUtil` and brought it into scope, but I need to learn about the `PsiBuilder` APIs to actually figure out how to leverage it. All I know is we can define rules in this class and expose them to our grammar.

This might even be a way we could delegate more directly to the rust parser, but it seems like if we could it would be better to leverage the rust parser further up, skipping the BNF-to-parser code generator step entirely. Research would be required either way.


### Comments/whitespace

Grammar-kit purportedly supports token splitting based on whitespace _"when a global token which does not appear in your grammar matches the pattern `' '`."_ Flux itself is quite liberal with what it considers whitespace, and in practical terms _comments_ should also be considered whitespace. Still, even when limiting ourselves to a single space defined as a global token the parser does not behave as expected.

For example, early in the sample flux the identifiers (split by lines):
```
// identifiers
a
_x
longIdentifierName
αβ

// int literals
```
This parses as a single identifier (whitespace between them removed) and then would produce parse error for the empty line between the last identifier and the following comment.

My workaround for this problem was to essentially go "fully manual" for whitespace control. This led to the addition of the `EmptyStatement` and `space` producers which are used to tell the parser where whitespace should be expected/permitted. This is not a great workaround. It really adds a lot of noise to the producer definitions.

Anyway, I don't have a good solution for this. It's a just a problem I had.

### Rule priority

As noted in the earlier section on unicode, global tokens defined using regex seem to "capture" tokens in odd ways making them difficult to compose rules around, seemingly related to relative priority.

As I worked through the section of the spec that described operators and expressions, much of the earlier work I did on literals seemed to break. I think a lot of the issues I saw could be attributed to associativity control (or a neglect towards it). The grammar might need to be reordered or otherwise re-engineered to get good results, compared to the spec.

In the sample flux linked above, you'll note a bunch of commented out lines that should parse but don't as well as FIXMEs related to thing parsing as other things (ex: date time literals parsing as `int MINUS int MINUS int <identifier starting with T>`, then failing to parse the rest when it encounters the `:` that separates the hours from the minutes.

There's also a bunch of ambiguity which I couldn't eliminate when it came to my naive matching of items like regex literals vs division vs line comments. All the `/`s were very confusing, especially when multiples appeared in close proximity. Seems like if we could identify the line comments first and drop them from consideration, these cases would be less ambiguous. Since character ranges are not really something we can express in Grammar-Kit without resorting to regex, and a poor regex at that, we likely need something smarter and less "global."

### Left-recursion

Just noting that the EBNF in the flux spec needs to be reorganized slightly to help grammar-kit switch to Pratt parsing for certain cases where left-recursion is found.

This post clued me into how to work around this: https://intellij-support.jetbrains.com/hc/en-us/community/posts/360001258300-What-s-the-alternative-to-left-recursion-in-GrammarKit-?page=1#community_comment_360000201199

Essentially the deal is you need to have a common root type in your grammar, then mark all the sub-types within it as `extends=RootType`. This allows the parser generator to eliminate the root type itself from the AST output, which allows it to tune the parser generator, thus allowing it to "pivot to Pratt."